### PR TITLE
use_syslog option fixed

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -11,8 +11,8 @@ tinyproxy::error_files: null
 tinyproxy::default_error_file: "/usr/share/tinyproxy/default.html"
 tinyproxy::stat_host: null
 tinyproxy::stat_file: "/usr/share/tinyproxy/stats.html"
-tinyproxy::log_file: "/var/log/tinyproxy/tinyproxy.log"
-tinyproxy::use_syslog: false
+tinyproxy::log_file: null
+tinyproxy::use_syslog: null
 tinyproxy::pid_file: "/var/run/tinyproxy/tinyproxy.pid"
 tinyproxy::use_xtinyproxy: false
 tinyproxy::default_upstreams: null

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -13,7 +13,7 @@ class tinyproxy::config (
   Optional[String] $stat_host,
   String $stat_file,
   Optional[String] $log_file,
-  Boolean $use_syslog,
+  Optional[Boolean] $use_syslog,
   String $pid_file,
   Boolean $use_xtinyproxy,
   Optional[Array[String]] $default_upstreams,
@@ -44,7 +44,7 @@ class tinyproxy::config (
 ){
 
   if $log_file != undef and $use_syslog == true {
-    fail('$use_syslog and $log_logfile are mutually exclusive.')
+    fail('$use_syslog and $log_file are mutually exclusive.')
   }
 
   file { $config_path:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class tinyproxy (
   Optional[String] $stat_host,
   String $stat_file,
   Optional[String] $log_file,
-  Boolean $use_syslog,
+  Optional[Boolean] $use_syslog,
   String $pid_file,
   Boolean $use_xtinyproxy,
   Optional[Array[String]] $default_upstreams,

--- a/templates/tinyproxy.conf.erb
+++ b/templates/tinyproxy.conf.erb
@@ -114,7 +114,11 @@ StatFile "<%= @stat_file %>"
 # and enable the Syslog directive.  These directives are mutually
 # exclusive.
 #
-<%- if @log_file -%>
+<%- if @log_file.nil? and ( @use_syslog.nil? or ! @use_syslog ) -%>
+LogFile "/var/log/tinyproxy/tinyproxy.log"
+<%- elsif @use_syslog -%>
+# LogFile "/var/log/tinyproxy/tinyproxy.log"
+<%- else -%>
 LogFile "<%= @log_file %>"
 <%- end -%>
 
@@ -123,10 +127,10 @@ LogFile "<%= @log_file %>"
 # option must not be enabled if the Logfile directive is being used.
 # These two directives are mutually exclusive.
 #
-<%- if @syslog.nil? -%>
+<%- if @use_syslog.nil? -%>
 #Syslog On
 <%- else -%>
-Syslog <%= @syslog ? 'On' : 'Off' %>
+Syslog <%= @use_syslog ? 'On' : 'Off' %>
 <%- end -%>
 
 #


### PR DESCRIPTION
Use_syslog option was not working due to typo in template conf file (misspelled variable name) and fact that default value for log_file was set in data/common.yaml and therefore condition on line 46 in manifest/config.pp could never be satisfied with use_syslog set to true.

Alteration made:
- template conf file:
    - variable name fixed
    - altered logic to set default log file value as needed, based on log_file and use_syslog variables
- data/common.yaml file:
    - set null as default value for both log_file and use_syslog variables
- manifest/config.pp and manifest/init.pp files:
    - set use_syslog variable as optional, since it does not have to be set always and in template conf file both 'null' and 'false' are handled as they should be
    - insignificant typo fix in manifest/config.pp
